### PR TITLE
[feat] Add RPM templates generation

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -6,6 +6,7 @@
   "package_name": "{{ cookiecutter.project_slug.replace('-', '_') }}",
   "project_url": "https://domain.tld",
   "project_short_description": "Project short description.",
+  "project_description": "Project detailed description.",
   "version": "0.1.0",
   "license": [
       "BSD license",
@@ -15,5 +16,10 @@
   "test_runner": [
       "unittest",
       "pytest"
+  ],
+  "rpm_packaging": [
+      "None",
+      "Using setuptools",
+      "Using a spec file"
   ]
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,0 +1,41 @@
+"""
+Does the following:
+
+    1. Removes the RPM packaging method not chosen
+
+"""
+import os
+import random
+import shutil
+import string
+from pprint import pprint
+
+PROJECT_DIRECTORY = os.path.realpath(os.path.curdir)
+
+# Global functions
+
+def remove_file(file_name):
+    if os.path.exists(file_name):
+        os.remove(file_name)
+
+def remove_tree(file_name):
+    if os.path.exists(file_name):
+        shutil.rmtree(file_name)
+
+# Remove unused RPM files 
+SPEC_FILE=os.path.join(PROJECT_DIRECTORY,'packaging/rpm/{{ cookiecutter.project_name }}.spec' )
+SETUPTOOLS_FILE=os.path.join(PROJECT_DIRECTORY,'packaging/rpm/{{ cookiecutter.project_name }}.sh' )
+
+if '{{ cookiecutter.rpm_packaging }}'.lower() == 'none':
+    remove_tree(os.path.join(PROJECT_DIRECTORY,'packaging/rpm'))
+else:
+    if '{{ cookiecutter.rpm_packaging }}'.lower() != 'using a spec file':
+        remove_file(SPEC_FILE)
+    if '{{ cookiecutter.rpm_packaging }}'.lower() != 'using setuptools':
+        remove_file(SETUPTOOLS_FILE)
+
+    
+
+
+
+

--- a/{{cookiecutter.project_slug}}/packaging/rpm/{{cookiecutter.project_slug}}.sh
+++ b/{{cookiecutter.project_slug}}/packaging/rpm/{{cookiecutter.project_slug}}.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+#
+# This script create RPM using python setuptools
+#
+
+
+
+# Common Functions 
+
+function usage () {
+	cat <<EOF
+SYNOPSIS
+	${0##*/} [Python version] [-h|--help]
+
+DESCRIPTION
+	This script create RPM using python setuptools
+COMMAND LINE OPTIONS
+	-h|--help	print this help
+	Python version	is the target python version, by default current system version ($(python -V 2>&1 | sed -r "s/[^[:space:]]*[[:space:]]([0-9]+(\.[0-9])?).*/\1/"))
+EOF
+
+}
+
+
+# Main
+if [[ "$1" =~ (-h|--help) ]]; then
+	usage
+elif [[ "$1" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+	PYTHON_VERSION="$1"
+	target_version="--target_version='$PYTHON_VERSION.0'"
+elif [ "$1" == "" ]; then
+	target_version=""
+else
+	echo "ERROR: $1 invalid argument"
+	usage
+	exit 1
+
+fi
+
+		
+
+cmd='python setup.py bdist_rpm \
+	--name="{{ cookiecutter.package_name }}" \
+	--description="{{ cookiecutter.project_short_description }}" \
+	--version="{{ cookiecutter.version }}"\
+	--author="{{ cookiecutter.author }}" \
+	--author_email="{{ cookiecutter.email }}" \
+	--licence="{{ cookiecutter.license }}" \
+	--url="{{ cookiecutter.project_url }}" \
+	--long_description="{{ cookiecutter.project_description }}" \
+	--release="0" \
+	--group="System Environment/Base" \
+	--packager="{{ cookiecutter.author }} <{{ cookiecutter.email }}>" \
+	--provides="{{ cookiecutter.package_name }}" \
+	--requires="python" \
+	$target_version'
+
+echo " Running Command : $cmd"
+
+$cmd
+	
+
+	
+

--- a/{{cookiecutter.project_slug}}/packaging/rpm/{{cookiecutter.project_slug}}.spec
+++ b/{{cookiecutter.project_slug}}/packaging/rpm/{{cookiecutter.project_slug}}.spec
@@ -1,0 +1,44 @@
+Summary: {{ cookiecutter.project_short_description }}
+Name: {{ cookiecutter.project_name }}
+Version: {{ cookiecutter.version }}
+Release: 0
+Copyright: {{ cookiecutter.license }}
+Group: System Environment/Base
+Source: {{ cookiecutter.project_url }}
+BuildRoot: /var/tmp/%{name}-buildroot
+Requires: python
+BuildRequires: python2-dev python3-dev py-setuptools
+Provides: {{ cookiecutter.package_name }}
+
+
+%description
+{{ cookiecutter.project_description }}
+
+%prep
+
+%build
+python2 setup.py build
+python3 setup.py build
+
+%install py2
+mkdir -p $RPM_BUILD_ROOT/%{_usr}
+python2 setup.py install --prefix=%{_usr} --root="$RPM_BUILD_ROOT" --skip-build
+
+%files py2
+%defattr(-,root,root)
+%{_usr}/lib/python2*
+
+%install py3
+mkdir -p $RPM_BUILD_ROOT/%{_usr}
+python3 setup.py install --prefix=%{_usr} --root="$RPM_BUILD_ROOT" --skip-build
+
+%files py3
+%defattr(-,root,root)
+%{_usr}/lib/python3*
+
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+%changelog
+


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Feature : Add initial version for RPM generation by two ways, traditionnal setuptools or using rpmutils with specfile
I added a port hook to cookie cutter to remove unsed files regarding the way chosen to build RPMs 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the component that receive modifications -->

##### VERSION
<!--- Paste current version used between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
